### PR TITLE
Fixed module check

### DIFF
--- a/src/moment.twitter.coffee
+++ b/src/moment.twitter.coffee
@@ -1,5 +1,5 @@
-hasModule = typeof module isnt 'undefined' and module.exports and typeof require isnt 'undefined'
-if hasModule?
+hasModule = module?.exports? and require?
+if hasModule
     moment = require 'moment'
 else
     moment = @moment


### PR DESCRIPTION
The module check was inaccurate - the existential operator in Coffeescript (`?`) will return true if the value is anything other than `null` or `undefined`. This means `hasModule?` will return true, even if `hasModule === false`.

I also removed the `typeof` checks in the `hasModule` definition - that's what the existential operator is good at :)
